### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require "rspec-sqlimit"
 
 RSpec.describe "N+1 safety" do
   it "doesn't send unnecessary requests to db" do
-    expect { User.create name: "Joe" }.not_to exceed_query_limit(1).with(/^INSERT/)
+    expect { User.create name: "Joe" }.not_to exceed_query_limit(0).with(/^INSERT/)
   end
 end
 ```


### PR DESCRIPTION
The example provided in the readme

```
expect { User.create name: "Joe" }.not_to exceed_query_limit(1).with(/^INSERT/)
```

The example output 
```
Failure/Error: expect { User.create }.not_to exceed_query_limit(0).with(/INSERT/)
```

So there should be `0` inserts in the rspec as shown by the output

cc @nepalez 